### PR TITLE
Fix Result.mapOrElse documentation example argument order

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,8 +347,8 @@ Maps a `Result<T, E>` to `F` by applying a function to a contained `Ok` value, o
 This function can be used to unpack a successful result while handling an error.
 
 ```ts
-Ok('asd').mapOrElse(a => a.repeat(2), b => b.message) // 'asdasd'
-Err('ohmybad').mapOrElse(a => a.repeat(2), b => b.message) // 'ohmybad'
+Ok('asd').mapOrElse(b => b.message, a => a.repeat(2)) // 'asdasd'
+Err('ohmybad').mapOrElse(b => b.message, a => a.repeat(2)) // 'ohmybad'
 ```
 
 #### ok

--- a/src/Result.ts
+++ b/src/Result.ts
@@ -155,8 +155,8 @@ class ResultLike<R, E> {
    * This function can be used to unpack a successful result while handling an error.
    *
    * ```ts
-   * Ok('asd').mapOrElse(a => a.repeat(2), b => b.message) // 'asdasd'
-   * Err('ohmybad').mapOrElse(a => a.repeat(2), b => b.message) // 'ohmybad'
+   * Ok('asd').mapOrElse(b => b.message, a => a.repeat(2)) // 'asdasd'
+   * Err('ohmybad').mapOrElse(b => b.message, a => a.repeat(2)) // 'ohmybad'
    * ```
    *
    * @template F


### PR DESCRIPTION
In the documentation of `Result.mapOrElse`, the fallback function appears as 1st argument instead of 2nd argument, according to the implementation.